### PR TITLE
Add -maxdepth filter option

### DIFF
--- a/include/filters.h
+++ b/include/filters.h
@@ -6,6 +6,7 @@
 struct FilterOptions {
     const char *name;
     const char *suffix;
+    int max_depth;
 };
 
 bool filter_match_name(const char *entry_name, const struct FilterOptions *filters);

--- a/src/main.c
+++ b/src/main.c
@@ -1,38 +1,47 @@
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
+
 #include "walk.h"
 #include "filters.h"
 
 int main(int argc, char *argv[]) {
     if (argc < 2) {
-        fprintf(stderr, "Usage: %s <path> [-name filename]\n", argv[0]);
+        fprintf(stderr, "Usage: %s <path> [-name filename] [-suffix ext] [-maxdepth N]\n", argv[0]);
         return 1;
     }
 
     struct FilterOptions filters = {0};
+    filters.max_depth = -1;
 
     const char *path = argv[1];
 
-    for(int i = 2; i < argc; i += 2) {
-        if (strcmp(argv[i], "-name") == 0){
+    for (int i = 2; i < argc; i += 2) {
+        if (strcmp(argv[i], "-name") == 0) {
             if (i + 1 >= argc) {
-                fprintf(stderr, "Sie brauchen ein Argument für die name Option");
+                fprintf(stderr, "Sie brauchen ein Argument für die name Option\n");
                 return 1;
             }
             filters.name = argv[i + 1];
-        } 
+        }
         else if (strcmp(argv[i], "-suffix") == 0) {
-            if (i+ 1 >= argc) {
-                fprintf(stderr, "Sie brauchen ein Argument für die suffix Option");
+            if (i + 1 >= argc) {
+                fprintf(stderr, "Sie brauchen ein Argument für die suffix Option\n");
                 return 1;
             }
             filters.suffix = argv[i + 1];
         }
-        else{
-                            fprintf(stderr, "Unbekannte Filteroption");
-                            return 1;
+        else if (strcmp(argv[i], "-maxdepth") == 0) {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "Sie brauchen ein Argument für die maxdepth Option\n");
+                return 1;
+            }
+            filters.max_depth = atoi(argv[i + 1]);
         }
-
+        else {
+            fprintf(stderr, "Unbekannte Filteroption\n");
+            return 1;
+        }
     }
 
     walk(path, &filters);

--- a/src/walk.c
+++ b/src/walk.c
@@ -8,7 +8,7 @@
 #include "filters.h"
 #include "walk.h"
 
-void walk(const char *path, const struct FilterOptions *filters) {
+static void walk_internal(const char *path, const struct FilterOptions *filters, int depth) {
     DIR *dir = opendir(path);
     if (dir == NULL) {
         perror(path);
@@ -40,11 +40,17 @@ void walk(const char *path, const struct FilterOptions *filters) {
             printf("%s\n", fullpath);
         }
 
-        // Wenn Verzeichnis → rekursiv weiterlaufen
+        // Wenn Verzeichnis → rekursiv weiterlaufen (nur wenn maxdepth erlaubt)
         if (S_ISDIR(st.st_mode)) {
-            walk(fullpath, filters);
+            if (filters->max_depth < 0 || depth < filters->max_depth) {
+                walk_internal(fullpath, filters, depth + 1);
+            }
         }
     }
 
     closedir(dir);
+}
+
+void walk(const char *path, const struct FilterOptions *filters) {
+    walk_internal(path, filters, 0);
 }


### PR DESCRIPTION
This PR adds support for the -maxdepth option.

The directory traversal is now limited by the given depth.
The option works together with existing filters like -name and -suffix.
